### PR TITLE
Enhancement - Default to the first seller profile while selling an item

### DIFF
--- a/lib/src/models/builders/product.dart
+++ b/lib/src/models/builders/product.dart
@@ -92,6 +92,7 @@ class ProductBuilder extends BuilderModel<Product> {
     descriptionController.addListener(notifyListeners);
     if (initialID == null) {
       productID = services.database.products.newID;
+      profile = otherProfiles[0];
       return;
     } else {
       await prefill();


### PR DESCRIPTION
The list in seller profile drop down is sorted according to the date time and the latest one is on top. I've set the default to be the first profile in the list.